### PR TITLE
Support refresh flag for job steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ The response body will echo back the submitted job description including the ID 
 * `environment` (`array` of `envVar`) - **Optional.** List of environment variables to be injected into this step's container.
 * `source` (`string`) - **Required.** Name of the Docker image to be executed for this step. If the tag is omitted from the image name, will default to "latest".
 * `output` (`string`) - **Optional.** Output channel to be captured and passed to the next step in the job. Valid values are "stdout", "stderr" or any absolute file path. Defaults to "stdout" if not specified. See the "Output Channels" section below for more details.
+* `refresh` (`boolean`) - **Optional.** Flag indicating whether or not the image identified by the *source* attribute should be refreshed before it is executed. A *true* value will force Dray to do a `docker pull` before the job step is started. A *false* value (the default) indicates that a `docker pull` should be done only if the image doesn't already exist in the local image cache.
 
 **Example Request:**
 

--- a/job/executor_test.go
+++ b/job/executor_test.go
@@ -1,9 +1,16 @@
 package job
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
 type mockExecutor struct {
@@ -38,4 +45,308 @@ func (m *mockExecutor) Inspect(job *Job) error {
 func (m *mockExecutor) CleanUp(job *Job) error {
 	args := m.Mock.Called(job)
 	return args.Error(0)
+}
+
+type JobStepExecutorTestSuite struct {
+	suite.Suite
+
+	job     *Job
+	jobStep *JobStep
+	mux     *http.ServeMux
+	server  *httptest.Server
+	jse     JobStepExecutor
+}
+
+func (suite *JobStepExecutorTestSuite) SetupTest() {
+	suite.mux = http.NewServeMux()
+	suite.server = httptest.NewServer(suite.mux)
+	suite.jse = NewExecutor(suite.server.URL)
+
+	suite.jobStep = &JobStep{
+		id:     "abc123",
+		Source: "foo",
+	}
+
+	suite.job = &Job{
+		Steps: []JobStep{*suite.jobStep},
+	}
+}
+
+func (suite *JobStepExecutorTestSuite) TearDownTest() {
+	suite.server.Close()
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_Success() {
+	id := "foo123abc"
+	stdIn := &bytes.Buffer{}
+	stdOutReader, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "{\"ID\":\"xyz789\"}")
+	})
+
+	suite.mux.HandleFunc("/containers/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, "{\"ID\":\""+id+"\"}")
+	})
+
+	attachPath := fmt.Sprintf("/containers/%s/attach", id)
+	suite.mux.HandleFunc(attachPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{1, 0, 0, 0, 0, 0, 0, 5})
+		w.Write([]byte("hello"))
+	})
+
+	startPath := fmt.Sprintf("/containers/%s/start", id)
+	suite.mux.HandleFunc(startPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.NoError(err)
+	suite.Equal(id, suite.job.CurrentStep().id)
+
+	stdOutScanner := bufio.NewScanner(stdOutReader)
+	stdOutScanner.Scan()
+	suite.Equal("hello", stdOutScanner.Text())
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_CreateError() {
+	stdIn := &bytes.Buffer{}
+	_, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "{\"ID\":\"xyz789\"}")
+	})
+
+	suite.mux.HandleFunc("/containers/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.EqualError(err, "API error (500): ")
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_StartError() {
+	id := "foo123abc"
+	stdIn := &bytes.Buffer{}
+	_, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "{\"ID\":\"xyz789\"}")
+	})
+
+	suite.mux.HandleFunc("/containers/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, "{\"ID\":\""+id+"\"}")
+	})
+
+	attachPath := fmt.Sprintf("/containers/%s/attach", id)
+	suite.mux.HandleFunc(attachPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{1, 0, 0, 0, 0, 0, 0, 5})
+		w.Write([]byte("hello"))
+	})
+
+	startPath := fmt.Sprintf("/containers/%s/start", id)
+	suite.mux.HandleFunc(startPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.EqualError(err, "API error (400): ")
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_MissingImage() {
+	pullCalled := false
+	id := "foo123abc"
+	stdIn := &bytes.Buffer{}
+	_, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	suite.mux.HandleFunc("/images/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		pullCalled = true
+	})
+
+	suite.mux.HandleFunc("/containers/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, "{\"ID\":\""+id+"\"}")
+	})
+
+	attachPath := fmt.Sprintf("/containers/%s/attach", id)
+	suite.mux.HandleFunc(attachPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{1, 0, 0, 0, 0, 0, 0, 5})
+		w.Write([]byte("hello"))
+	})
+
+	startPath := fmt.Sprintf("/containers/%s/start", id)
+	suite.mux.HandleFunc(startPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.NoError(err)
+	suite.True(pullCalled, "Docker image not pulled")
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_PullError() {
+	pullCalled := false
+	stdIn := &bytes.Buffer{}
+	_, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	suite.mux.HandleFunc("/images/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		pullCalled = true
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.EqualError(err, "API error (404): ")
+	suite.True(pullCalled, "Docker image not pulled")
+}
+
+func (suite *JobStepExecutorTestSuite) TestStart_ForceRefresh() {
+	suite.job.CurrentStep().Refresh = true
+	inspectCalled := false
+	pullCalled := false
+	removeCalled := false
+	imageID := "xyz890"
+	id := "foo123abc"
+	stdIn := &bytes.Buffer{}
+	_, stdOutWriter := io.Pipe()
+	_, stdErrWriter := io.Pipe()
+
+	inspectPath := fmt.Sprintf("/images/%s/json", suite.jobStep.Source)
+	suite.mux.HandleFunc(inspectPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if inspectCalled {
+			fmt.Fprintf(w, "{\"Id\":\"%s\"}", "15930e")
+		} else {
+			fmt.Fprintf(w, "{\"Id\":\"%s\"}", imageID)
+		}
+		inspectCalled = true
+	})
+
+	suite.mux.HandleFunc("/images/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		pullCalled = true
+	})
+
+	removePath := fmt.Sprintf("/images/%s", imageID)
+	suite.mux.HandleFunc(removePath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		removeCalled = true
+	})
+
+	suite.mux.HandleFunc("/containers/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, "{\"ID\":\"%s\"}", id)
+	})
+
+	attachPath := fmt.Sprintf("/containers/%s/attach", id)
+	suite.mux.HandleFunc(attachPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte{1, 0, 0, 0, 0, 0, 0, 5})
+		w.Write([]byte("hello"))
+	})
+
+	startPath := fmt.Sprintf("/containers/%s/start", id)
+	suite.mux.HandleFunc(startPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := suite.jse.Start(suite.job, stdIn, stdOutWriter, stdErrWriter)
+
+	suite.NoError(err)
+	suite.True(pullCalled, "Docker image not pulled")
+	suite.True(removeCalled, "Docker image not removed")
+}
+
+func (suite *JobStepExecutorTestSuite) TestInspect_Success() {
+	path := fmt.Sprintf("/containers/%s/json", suite.jobStep.id)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("GET", r.Method)
+		fmt.Fprint(w, "{\"State\":{\"ExitCode\":0}}")
+	})
+
+	err := suite.jse.Inspect(suite.job)
+
+	suite.NoError(err)
+}
+
+func (suite *JobStepExecutorTestSuite) TestInspect_Error() {
+	path := fmt.Sprintf("/containers/%s/json", suite.jobStep.id)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("GET", r.Method)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	err := suite.jse.Inspect(suite.job)
+
+	suite.EqualError(err, "No such container: abc123")
+}
+
+func (suite *JobStepExecutorTestSuite) TestInspect_ErrorExit() {
+	path := fmt.Sprintf("/containers/%s/json", suite.jobStep.id)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("GET", r.Method)
+		fmt.Fprint(w, "{\"State\":{\"ExitCode\":99}}")
+	})
+
+	err := suite.jse.Inspect(suite.job)
+
+	suite.EqualError(err, "Container exit code: 99")
+}
+
+func (suite *JobStepExecutorTestSuite) TestCleanUp_Success() {
+	path := fmt.Sprintf("/containers/%s", suite.jobStep.id)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("DELETE", r.Method)
+	})
+
+	err := suite.jse.CleanUp(suite.job)
+
+	suite.NoError(err)
+}
+
+func (suite *JobStepExecutorTestSuite) TestCleanUp_Error() {
+	path := fmt.Sprintf("/containers/%s", suite.jobStep.id)
+	suite.mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("DELETE", r.Method)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	err := suite.jse.CleanUp(suite.job)
+
+	suite.EqualError(err, "No such container: abc123")
+}
+
+func TestJobStepExecutor(t *testing.T) {
+	suite.Run(t, new(JobStepExecutorTestSuite))
 }

--- a/job/types.go
+++ b/job/types.go
@@ -57,6 +57,7 @@ type JobStep struct {
 	Output         string      `json:"output,omitempty"`
 	BeginDelimiter string      `json:"beginDelimiter,omitempty"`
 	EndDelimiter   string      `json:"endDelimiter,omitempty"`
+	Refresh        bool        `json:"refresh,omitempty"`
 }
 
 type Environment []EnvVar


### PR DESCRIPTION
Adds the boolean `Refresh` attribute on the `JobStep` which indicates whether or not to force a "docker pull" before executing a step. This can be used to ensure that you always have the freshest version of an image before it is executed.

After the image is refreshed, any orphaned layers are automatically removed.